### PR TITLE
Update consts.ts

### DIFF
--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_NETWORK_URL = "ws://127.0.0.1:9944";
 export const DEFAULT_ASTAR_NETWORK_URL = "wss://rpc.astar.network";
 export const DEFAULT_SHIDEN_NETWORK_URL = "wss://rpc.shiden.astar.network";
-export const DEFAULT_SHIBUYA_NETWORK_URL = "wss://rpc.shibuya.astar.network";
+export const DEFAULT_SHIBUYA_NETWORK_URL = "wss://shibuya.public.blastapi.io";
 
 export const ARTIFACTS_PATH = "artifacts";
 export const TYPED_CONTRACTS_PATH = "typedContracts";


### PR DESCRIPTION
 wss://rpc.shibuya.astar.network (only EVM/Ethereum RPC available) so updating to endpoint compatible with Wasm contracts